### PR TITLE
Add no include dirs for windows

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -70,5 +70,6 @@ class LibiconvConan(ConanFile):
             self.cpp_info.libs = ['charset', 'iconv']
             if self.settings.os == "Linux" or (self.options.shared and self.settings.os == "Macos"):
                 self.cpp_info.defines.append("LIBICONV_PLUG=1")
-
+        elif self.settings.os == "Windows":
+            self.cpp_info.includedirs = []
 


### PR DESCRIPTION
Fixes this issue when using modern CMake on windows:

```
Imported target ... includes non-existent path

    "E:/.conan/data/libiconv/1.14/lasote/stable/package/2e96ff36c6b64b6dbeed57ff33c1ef49383c9f64/include"

  in its INTERFACE_INCLUDE_DIRECTORIES
```